### PR TITLE
rewrite & speedup vga code, optimize make options  squelch gcc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ OBJS := $(SRCS:.c=.o)
 EXEC := emulate    
 
 # set the compiler flags
-CFLAGS := `sdl2-config --libs --cflags` -ggdb3 -O0 --std=c99 -Wall -lSDL2_image -lSDL2_ttf -lm
+CFLAGS := `sdl2-config --libs --cflags` -ggdb3 -O2 -march=native --std=c99 -Wall -lSDL2_image -lSDL2_ttf -lm
 
 # default recipe
 all: $(EXEC)

--- a/input.c
+++ b/input.c
@@ -58,6 +58,8 @@ uint8_t GetControllerInput()
                 inputDev = GT_KEYBOARD;
                 printf("%s\n","keyboard");
                 break;
+            default:
+				inputByte = 255;
             }
             break;
         case SDL_KEYUP:


### PR DESCRIPTION
	modified:   Makefile
		-O2 -march=native

	modified:   emulator.c
		rewrite vga code, only draw pixel when changed.

	modified:   input.c
		squelch gcc complaint about missing switch cases.